### PR TITLE
Fix menu click handler

### DIFF
--- a/themes/next/source/js/next-boot.js
+++ b/themes/next/source/js/next-boot.js
@@ -8,7 +8,7 @@ NexT.boot.registerEvents = function() {
   NexT.utils.registerCanIUseTag();
 
   // Mobile top menu bar.
-  document.querySelector('.site-nav-toggle .toggle').addEventListener('click', () => {
+  document.querySelector('.site-nav-toggle .toggle').addEventListener('click', event => {
     event.currentTarget.classList.toggle('toggle-close');
     var siteNav = document.querySelector('.site-nav');
     var animateAction = siteNav.classList.contains('site-nav-on') ? 'slideUp' : 'slideDown';


### PR DESCRIPTION
## Summary
- fix menu click handler in theme: pass event parameter so `event.currentTarget` is defined

## Testing
- `npx hexo generate`

------
https://chatgpt.com/codex/tasks/task_e_6852d664141883268a143b285e3850f9